### PR TITLE
Add compatibility for ROS Melodic on Ubuntu 18.04

### DIFF
--- a/uav_simulator/Utils/multi_map_server/CMakeLists.txt
+++ b/uav_simulator/Utils/multi_map_server/CMakeLists.txt
@@ -166,7 +166,7 @@ add_dependencies(multi_map_visualization multi_map_server_messages_cpp)
 target_link_libraries(multi_map_visualization 
    ${catkin_LIBRARIES}
    ${ARMADILLO_LIBRARIES}
-   pose_utils
+   ${pose_utils_LIBRARIES}
 )
 
 #############

--- a/uav_simulator/Utils/odom_visualization/CMakeLists.txt
+++ b/uav_simulator/Utils/odom_visualization/CMakeLists.txt
@@ -159,7 +159,7 @@ add_executable(odom_visualization src/odom_visualization.cpp)
 target_link_libraries(odom_visualization
    ${catkin_LIBRARIES}
    ${ARMADILLO_LIBRARIES}
-   pose_utils
+   ${pose_utils_LIBRARIES}
 )
 
 #############

--- a/uav_simulator/so3_control/src/so3_control_nodelet.cpp
+++ b/uav_simulator/so3_control/src/so3_control_nodelet.cpp
@@ -214,5 +214,4 @@ SO3ControlNodelet::onInit(void)
 }
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(so3_control, SO3ControlNodelet, SO3ControlNodelet,
-                        nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(SO3ControlNodelet, nodelet::Nodelet);

--- a/uav_simulator/so3_disturbance_generator/CMakeLists.txt
+++ b/uav_simulator/so3_disturbance_generator/CMakeLists.txt
@@ -71,6 +71,6 @@ add_dependencies(so3_disturbance_generator ${PROJECT_NAME}_gencfg)
 target_link_libraries(so3_disturbance_generator 
    ${catkin_LIBRARIES}
    ${ARMADILLO_LIBRARIES}
-   pose_utils 
+   ${pose_utils_LIBRARIES}
 )
 


### PR DESCRIPTION
## Summary

I'm working on this project on ROS Melodic and stumble across small issues to build it but manage to resolve it and am proceeding to the next step. Hope everyone can benefit from the following notes.

## Configurations
- OS: Ubuntu 18.04.4 LTS
- ROS Distro: melodic
- ROS Version: 1.14.9
- catkin_tools: 0.6.1
- Python: 2.7.17

## Replication Steps
```
  sudo apt-get install libnlopt-dev libarmadillo-dev
  cd ${YOUR_WORKSPACE_PATH}/src
  git clone https://github.com/HKUST-Aerial-Robotics/Fast-Planner.git
  cd ../
  catkin build
```

---
_Side note_: My installation of`nlopt` library require an extra step to symlink otherwise it couldn't detect it

```
$ sudo apt-get install libnlopt-dev
$ dpkg -L libnlopt-dev
...
/usr/lib/x86_64-linux-gnu/libnlopt.so
...
$ sudo ln -s /usr/lib/x86_64-linux-gnu/libnlopt.so /usr/local/lib/libnlopt.so
```

Also, a quick `catkin build multi_map_server` resolved the following problem

```
/Fast-Planner/uav_simulator/Utils/multi_map_server/src/multi_map_visualization.cc:5:10: fatal error: multi_map_server/MultiOccupancyGrid.h: No such file or directory
 #include <multi_map_server/MultiOccupancyGrid.h>
```